### PR TITLE
Add support for Input System

### DIFF
--- a/Prefabs/DeveloperConsole.prefab
+++ b/Prefabs/DeveloperConsole.prefab
@@ -183,6 +183,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 59f2102d7131cfb44a22b8e4464783a2, type: 2}
   - {fileID: 11400000, guid: be8a611cc43be5744b79767982cea0ac, type: 2}
   - {fileID: 11400000, guid: 20ec1ca2bbd44e94faca660ddbecfd80, type: 2}
+  - {fileID: 11400000, guid: 4d8fc261eb820ce49886d68aa0614237, type: 2}
   uiCanvas: {fileID: 855559481631051708}
   inputField: {fileID: 855559482485143244}
   logUI: {fileID: 855559482330210214}

--- a/Scripts/DeveloperConsoleUI.cs
+++ b/Scripts/DeveloperConsoleUI.cs
@@ -131,12 +131,7 @@ namespace Hibzz.Console
 			if(!inputField.isFocused)
 			{
 				uiCanvas.SetActive(true);
-
-				#if ENABLE_INPUT_SYSTEM
-				#else
-				inputField.text += ((char)activationKeyCode);
-				#endif
-
+				inputField.text += prefix;
 				inputField.ActivateInputField();
 				inputField.caretPosition = inputField.text.Length;
 			}

--- a/Scripts/OpenHyperlinks.cs
+++ b/Scripts/OpenHyperlinks.cs
@@ -7,6 +7,10 @@ using UnityEngine;
 using TMPro;
 using UnityEngine.EventSystems;
 
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+
 namespace Hibzz.Console
 {
 	[RequireComponent(typeof(TMP_Text))]
@@ -22,7 +26,11 @@ namespace Hibzz.Console
 		public void OnPointerClick(PointerEventData eventData)
 		{
 			// This enables ctrl + click to open the link
+			#if ENABLE_INPUT_SYSTEM
+			if(!Keyboard.current[Key.LeftCtrl].isPressed) { return; }
+			#else
 			if(!Input.GetKey(KeyCode.LeftControl)) { return; }
+			#endif
 
 			// find if the text at the given position has any links in it
 			int linkIndex = TMP_TextUtilities.FindIntersectingLink(text, Input.mousePosition, null);

--- a/com.hibzz.console.asmdef
+++ b/com.hibzz.console.asmdef
@@ -2,7 +2,8 @@
     "name": "hibzz.unity.console",
     "rootNamespace": "",
     "references": [
-        "GUID:6055be8ebefd69e48b49212b09b47b2f"
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
+        "GUID:75469ad4d38634e559750d17036d5f7c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
### Brief
This update adds support for the users who may solely use the newer Unity Input System Package. The functionality is extremely identical to the older `Unity.Input` system, providing an out-of-the-box experience for the `Hibzz.Console` users.